### PR TITLE
feat(drift-fix-claude): Vertex AI 認証の追加（Workload Identity Federation）

### DIFF
--- a/drift-fix-claude/action.yaml
+++ b/drift-fix-claude/action.yaml
@@ -16,13 +16,10 @@ inputs:
     description: GitHub token (GitHub App or PAT is required to trigger workflows)
   anthropic-vertex-project-id:
     description: Anthropic Vertex AI project ID
-    default: gmomediadatadev
   cloud-ml-region:
     description: Cloud ML region for Vertex AI
-    default: global
   anthropic-model:
     description: Anthropic model to use
-    default: claude-sonnet-4-6
 
   base-branch:
     description: Base branch for the PR

--- a/drift-fix-claude/action.yaml
+++ b/drift-fix-claude/action.yaml
@@ -14,6 +14,12 @@ inputs:
 
   github-token:
     description: GitHub token (GitHub App or PAT is required to trigger workflows)
+  workload-identity-provider:
+    description: Workload Identity Provider for Google Cloud authentication (required for Vertex AI)
+    required: true
+  service-account:
+    description: Service account email for Google Cloud authentication (required for Vertex AI)
+    required: true
   anthropic-vertex-project-id:
     description: Anthropic Vertex AI project ID
   cloud-ml-region:
@@ -50,6 +56,12 @@ runs:
         BRANCH_NAME="fix-drift-$(echo '${{ inputs.dir }}' | tr '/' '-')-$(date +%Y%m%d-%H%M%S)"
         git checkout -b "$BRANCH_NAME"
         echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      with:
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        service_account: ${{ inputs.service-account }}
 
     - name: Save plan to file
       shell: bash

--- a/drift-fix-claude/action.yaml
+++ b/drift-fix-claude/action.yaml
@@ -14,10 +14,15 @@ inputs:
 
   github-token:
     description: GitHub token (GitHub App or PAT is required to trigger workflows)
-  anthropic-api-key:
-    description: Anthropic API key
-  claude-code-oauth-token:
-    description: Claude Code OAuth token (alternative to anthropic_api_key)
+  anthropic-vertex-project-id:
+    description: Anthropic Vertex AI project ID
+    default: gmomediadatadev
+  cloud-ml-region:
+    description: Cloud ML region for Vertex AI
+    default: global
+  anthropic-model:
+    description: Anthropic model to use
+    default: claude-sonnet-4-6
 
   base-branch:
     description: Base branch for the PR
@@ -55,37 +60,33 @@ runs:
         PLAN: ${{ inputs.plan }}
       run: echo "$PLAN" > /tmp/plan.txt
 
-    - name: Setup Claude Code
-      shell: bash
-      run: |
-        curl -fsSL https://claude.ai/install.sh | bash -s latest
-        export PATH="~/.local/bin:$PATH"
-
     # Use Claude Code to fix the drift
     - name: Fix drift with Claude Code
-      shell: bash
-      run: |
-        echo "$PROMPT" | \
-          claude -p --verbose --output-format stream-json \
-          --allowedTools "Bash,Edit,Glob,Grep,LS,MultiEdit,Read,Task,TodoWrite,WebFetch,WebSearch,Write" \
-          --disallowedTools "Bash(${{ steps.config.outputs.tf-binary }}  apply),Bash(git commit),Bash(git push)"
+      uses: anthropics/claude-code-base-action@eee9e25eaeacec8bd408cda169d11f0e2e5c02c6
+      continue-on-error: true
       env:
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude-code-oauth-token }}
-        PROMPT: |
+        ANTHROPIC_VERTEX_PROJECT_ID: ${{ inputs.anthropic-vertex-project-id }}
+        CLOUD_ML_REGION: ${{ inputs.cloud-ml-region }}
+        ANTHROPIC_MODEL: ${{ inputs.anthropic-model }}
+      with:
+        use_vertex: "true"
+        claude_args: >-
+          --allowedTools "Bash,Edit,Glob,Grep,LS,MultiEdit,Read,Task,TodoWrite,WebFetch,WebSearch,Write"
+          --disallowedTools "Bash(${{ steps.config.outputs.tf-binary }} apply),Bash(git commit),Bash(git push)"
+        prompt: |
           # CRITICAL INSTRUCTIONS FOR FIXING INFRASTRUCTURE DRIFT
           You have been given a critical task to fix infrastructure drift in Terraform/OpenTofu configuration files.
           Your goal is to update the .tf files to match the current real-world infrastructure state.
 
           ## Important Rules
           - NEVER run `${{ steps.config.outputs.tf-binary }} apply` even if there is a need to update tfstate. Preserve the existing infrastructure state.
-          - Only make changes to .tf files and run `${{ steps.config.outputs.tf-binary }}  plan`.
+          - Only make changes to .tf files and run `${{ steps.config.outputs.tf-binary }} plan`.
           - Always choose the least destructive approach. Be surgical and precise with your edits.
-          
+
           ## Context
           - Directory with drift: ${{ inputs.dir }}
           - The plan result is in /tmp/plan.txt
-          
+
           ## YOUR MISSION - FOLLOW THESE STEPS EXACTLY:
           1. Read the plan and understand the changes
           The plan is trying to *revert* the external changes done to the infrastructure.
@@ -98,16 +99,16 @@ runs:
           "t3.micro" is the real infrastructure state, while "t2.micro" is what's in our .tf files.
           This means a user may have manually changed the instance type from t2.micro to t3.micro, and didn't update the .tf file.
           You should update the .tf file to match reality - "t3.micro".
-          
+
           The plan is usually quite verbose with default values.
           Try not to be confused by these verbose lines - try to extract only the important changes.
-          
+
           2. Fix the drift
           Update .tf files to match the CURRENT REAL INFRASTRUCTURE STATE.
           This means: incorporate the external changes into your .tf files.
-          
+
           3. Validate
-          After making changes, run: `${{ steps.config.outputs.tf-binary }}  plan` within directory `${{ inputs.dir }}`.
+          After making changes, run: `${{ steps.config.outputs.tf-binary }} plan` within directory `${{ inputs.dir }}`.
           The plan MUST show "No changes. Your infrastructure matches the configuration."
           If there are still differences, continue fixing until plan shows no changes.
 


### PR DESCRIPTION
## Summary

`drift-fix-claude` アクションに Vertex AI 用の GCP 認証ステップを追加。

- `workload-identity-provider` / `service-account` inputs を追加
- `google-github-actions/auth@v3` による Workload Identity Federation 認証を Claude Code 実行前に挿入

## Background

`drift-fix-claude` は `use_vertex: "true"` で Claude Code を呼び出すが、GCP の Application Default Credentials が設定されていないため `Could not load the default credentials` エラーが発生していた。

## Test plan

- [ ] `workload-identity-provider` / `service-account` を渡した状態で drift が検出された際に Claude Code が正常に起動することを確認
- [ ] GCP 認証なしで呼び出した場合に `required: true` でエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)