### PR TITLE
feat(drift-fix-claude): driftが解消されているかを論理で確認する

### DIFF
--- a/drift-fix-claude/action.yaml
+++ b/drift-fix-claude/action.yaml
@@ -166,7 +166,7 @@ runs:
         DIR: ${{ inputs.dir }}
         TF_BINARY: ${{ steps.config.outputs.tf-binary }}
         MODE: ${{ steps.guard.outputs.mode }}
-        EXISTING_PR_NUMBER: ""
+        EXISTING_PR_NUMBER: ${{ steps.guard.outputs.existing-pr-number }}
       run: '"$GITHUB_ACTION_PATH/scripts/verify-drift-resolved.sh"'
 
     # Commit the changes (also for unverified fixes, so they can be handed
@@ -195,5 +195,5 @@ runs:
         BRANCH_NAME: ${{ steps.branch.outputs.name }}
         VERDICT: ${{ steps.verify.outputs.verdict }}
         MODE: ${{ steps.guard.outputs.mode }}
-        EXISTING_PR_NUMBER: ""
+        EXISTING_PR_NUMBER: ${{ steps.guard.outputs.existing-pr-number }}
       run: '"$GITHUB_ACTION_PATH/scripts/create-pr.sh"'

--- a/drift-fix-claude/action.yaml
+++ b/drift-fix-claude/action.yaml
@@ -47,9 +47,12 @@ outputs:
   skipped:
     description: "true if the fix was skipped: auto-fix is not configured (missing Vertex AI inputs)"
     value: ${{ steps.guard.outputs.skip }}
+  fix-verified:
+    description: "'true' if the fix was verified (plan shows no changes), 'false' if a draft PR was created unverified, empty when no PR was created"
+    value: ${{ steps.verify.outputs.fix-verified }}
   summary:
     description: One-line outcome for notification (skip reason or PR URL). Empty on hard failure.
-    value: ${{ steps.guard.outputs.summary || steps.create-pr.outputs.summary }}
+    value: ${{ steps.guard.outputs.summary || steps.create-pr.outputs.summary || steps.verify.outputs.summary }}
 
 runs:
   using: composite
@@ -125,7 +128,8 @@ runs:
     # that predates skill auto-loading from --add-dir directories (2.1.32).
     # continue-on-error: a mid-run Claude failure (API error, credential
     # expiry, max-turns) may still leave useful partial edits. Do NOT let it
-    # abort the action; the commit step below will push whatever was edited.
+    # abort the action; the no-change gate below re-runs plan and decides the
+    # fate of whatever was edited.
     - name: Fix drift with Claude Code
       if: ${{ steps.guard.outputs.skip != 'true' }}
       uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e # v1.0.145
@@ -148,9 +152,27 @@ runs:
           --allowedTools "Bash,Edit,Glob,Grep,LS,MultiEdit,Read,Task,TodoWrite,WebFetch,WebSearch,Write"
           --disallowedTools "Bash(${{ steps.config.outputs.tf-binary }} apply:*),Bash(git commit:*),Bash(git push:*)"
 
-    # Commit the changes. See scripts/commit-and-push.sh.
-    - name: Commit changes
+    # No-change gate: deterministically verify Claude's fix by re-running
+    # plan and requiring "No changes". A remaining plan that would destroy
+    # and recreate (-/+) a resource is never handed off, even as a draft PR.
+    # See scripts/verify-drift-resolved.sh; the verdict mapping lives in
+    # scripts/no-change-gate.sh.
+    - name: Verify drift is resolved (no-change gate)
+      id: verify
       if: ${{ steps.guard.outputs.skip != 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        DIR: ${{ inputs.dir }}
+        TF_BINARY: ${{ steps.config.outputs.tf-binary }}
+        MODE: ${{ steps.guard.outputs.mode }}
+        EXISTING_PR_NUMBER: ""
+      run: '"$GITHUB_ACTION_PATH/scripts/verify-drift-resolved.sh"'
+
+    # Commit the changes (also for unverified fixes, so they can be handed
+    # off to a human as a draft PR). See scripts/commit-and-push.sh.
+    - name: Commit changes
+      if: ${{ steps.guard.outputs.skip != 'true' && (steps.verify.outputs.verdict == 'pr' || steps.verify.outputs.verdict == 'draft-pr') }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}
@@ -158,10 +180,11 @@ runs:
         BRANCH_NAME: ${{ steps.branch.outputs.name }}
       run: '"$GITHUB_ACTION_PATH/scripts/commit-and-push.sh"'
 
-    # Create a pull request if changes were committed.
+    # Create a pull request if changes were made. Unverified fixes
+    # (verdict=draft-pr) become a draft PR so a human can finish the fix.
     # See scripts/create-pr.sh.
     - name: Create or update Pull Request
-      if: ${{ steps.guard.outputs.skip != 'true' }}
+      if: ${{ steps.guard.outputs.skip != 'true' && (steps.verify.outputs.verdict == 'pr' || steps.verify.outputs.verdict == 'draft-pr') }}
       id: create-pr
       shell: bash
       env:
@@ -170,7 +193,7 @@ runs:
         TF_BINARY: ${{ steps.config.outputs.tf-binary }}
         BASE_BRANCH: ${{ inputs.base-branch }}
         BRANCH_NAME: ${{ steps.branch.outputs.name }}
-        VERDICT: pr
+        VERDICT: ${{ steps.verify.outputs.verdict }}
         MODE: ${{ steps.guard.outputs.mode }}
         EXISTING_PR_NUMBER: ""
       run: '"$GITHUB_ACTION_PATH/scripts/create-pr.sh"'

--- a/drift-fix-claude/scripts/create-pr.sh
+++ b/drift-fix-claude/scripts/create-pr.sh
@@ -6,8 +6,9 @@
 # later cron runs from re-running Claude while the PR stays valid.
 #
 # Env:    GH_TOKEN, DIR, TF_BINARY, BASE_BRANCH, BRANCH_NAME, VERDICT,
-#         MODE, EXISTING_PR_NUMBER (only when MODE=update)
-# Reads:  /tmp/verify-plan.txt (written by verify-drift-resolved.sh)
+#         MODE, EXISTING_PR_NUMBER (only when MODE=update),
+#         VERIFY_PLAN_TXT (set by verify-drift-resolved.sh via GITHUB_ENV)
+# Reads:  "$VERIFY_PLAN_TXT" (written by verify-drift-resolved.sh)
 # Writes: pr-url / summary to GITHUB_OUTPUT
 set -euo pipefail
 
@@ -18,6 +19,7 @@ set -euo pipefail
 : "${VERDICT:?VERDICT is required}"
 : "${MODE:?MODE is required}"
 : "${GH_TOKEN:?GH_TOKEN is required}"
+: "${VERIFY_PLAN_TXT:?VERIFY_PLAN_TXT is required (set by verify-drift-resolved.sh via GITHUB_ENV)}"
 
 # Check if changes were pushed. In update mode the PR branch always exists
 # on origin, so this never triggers there; pushes are guaranteed by the
@@ -49,7 +51,7 @@ if [ "$VERDICT" = "draft-pr" ]; then
     # line with no trailing newline; awk treats that fragment as a
     # record and print appends a newline, so the last line is still
     # indented and terminated (sed would leave it unterminated).
-    head -c 40000 /tmp/verify-plan.txt | awk '{ print "    " $0 }'
+    head -c 40000 "$VERIFY_PLAN_TXT" | awk '{ print "    " $0 }'
     echo
     echo
   } >> "$BODY_FILE"

--- a/drift-fix-claude/scripts/no-change-gate.sh
+++ b/drift-fix-claude/scripts/no-change-gate.sh
@@ -20,6 +20,7 @@
 #                  an unexpected exit code, or inconsistent inputs)
 #
 # Pure mapping with no side effects; exits non-zero only on invalid usage.
+# Logic: branch on plan exit code first, then check secondary conditions.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -41,12 +42,15 @@ for flag in "HAS_DIFF=$HAS_DIFF" "HAS_REPLACE=$HAS_REPLACE"; do
   esac
 done
 
-# "No changes" output (exit 0) cannot contain a replacement; that
-# combination means the inputs are inconsistent -> fall through to fail.
-case "$PLAN_EXIT_CODE:$HAS_DIFF:$HAS_REPLACE" in
-  0:true:false)  echo "pr" ;;
-  0:false:false) echo "resolved" ;;
-  2:true:true)   echo "replace-fail" ;;
-  2:true:false)  echo "draft-pr" ;;
-  *)             echo "fail" ;;
+case "$PLAN_EXIT_CODE" in
+  0)
+    if [ "$HAS_DIFF" = "true" ]; then echo "pr"; else echo "resolved"; fi
+    ;;
+  2)
+    if   [ "$HAS_REPLACE" = "true" ]; then echo "replace-fail"
+    elif [ "$HAS_DIFF"    = "true" ]; then echo "draft-pr"
+    else echo "fail"
+    fi
+    ;;
+  *) echo "fail" ;;
 esac

--- a/drift-fix-claude/scripts/no-change-gate.sh
+++ b/drift-fix-claude/scripts/no-change-gate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Decide the no-change-gate verdict from the verification plan result.
+#
+# Usage: no-change-gate.sh PLAN_EXIT_CODE HAS_DIFF HAS_REPLACE
+#   PLAN_EXIT_CODE: exit code of `<tf-binary> plan -detailed-exitcode`
+#                   (0 = no changes, 2 = changes present, 1 = error)
+#   HAS_DIFF:       "true" if the working tree has local changes
+#                   (git status --porcelain non-empty), else "false"
+#   HAS_REPLACE:    "true" if the plan output contains a resource
+#                   replacement (-/+ or +/- "must be replaced"), else "false"
+#
+# Prints exactly one verdict to stdout:
+#   pr           - drift fixed and changes exist -> create a normal PR
+#   resolved     - nothing edited and no drift left -> already resolved, no PR
+#   draft-pr     - changes exist but drift remains -> hand off as a draft PR
+#                  (create-only / destroy-only changes are tolerated here)
+#   replace-fail - the remaining plan would destroy AND recreate a resource
+#                  -> never hand off a PR that replaces resources
+#   fail         - nothing to hand off (no edits with drift left, plan error,
+#                  an unexpected exit code, or inconsistent inputs)
+#
+# Pure mapping with no side effects; exits non-zero only on invalid usage.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 PLAN_EXIT_CODE HAS_DIFF HAS_REPLACE" >&2
+  exit 64
+fi
+
+PLAN_EXIT_CODE="$1"
+HAS_DIFF="$2"
+HAS_REPLACE="$3"
+
+for flag in "HAS_DIFF=$HAS_DIFF" "HAS_REPLACE=$HAS_REPLACE"; do
+  case "${flag#*=}" in
+    true|false) ;;
+    *)
+      echo "${flag%%=*} must be 'true' or 'false', got: ${flag#*=}" >&2
+      exit 64
+      ;;
+  esac
+done
+
+# "No changes" output (exit 0) cannot contain a replacement; that
+# combination means the inputs are inconsistent -> fall through to fail.
+case "$PLAN_EXIT_CODE:$HAS_DIFF:$HAS_REPLACE" in
+  0:true:false)  echo "pr" ;;
+  0:false:false) echo "resolved" ;;
+  2:true:true)   echo "replace-fail" ;;
+  2:true:false)  echo "draft-pr" ;;
+  *)             echo "fail" ;;
+esac

--- a/drift-fix-claude/scripts/run-verify-plan.sh
+++ b/drift-fix-claude/scripts/run-verify-plan.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run `<tf-binary> plan` for drift verification and capture its output.
+# Shared by guard-existing-pr.sh (stale-PR detection) and
+# verify-drift-resolved.sh (no-change gate) so both use identical plan
+# conditions.
+#
+# Usage: run-verify-plan.sh OUT_FILE
+# Env:   DIR, TF_BINARY
+# Exit:  the plan's exit code, passed through unmodified
+#        (0 = no changes, 2 = changes present, 1 = error)
+set -euo pipefail
+
+OUT_FILE="${1:?usage: run-verify-plan.sh OUT_FILE}"
+: "${DIR:?DIR is required}"
+: "${TF_BINARY:?TF_BINARY is required}"
+
+# tofu supports -concise to drop the refresh noise; terraform does not
+CONCISE_FLAG=""
+case "$TF_BINARY" in
+  *tofu*) CONCISE_FLAG="-concise" ;;
+esac
+
+set +e
+# -no-color: the output is embedded in the PR body / job summary.
+# 2>&1: plan errors go to stderr; capture them so the fail branch and
+# the draft PR body are not empty on exit code 1.
+(cd "$DIR" && "$TF_BINARY" plan -no-color -lock-timeout=300s $CONCISE_FLAG -detailed-exitcode) > "$OUT_FILE" 2>&1
+exit $?

--- a/drift-fix-claude/scripts/run-verify-plan.sh
+++ b/drift-fix-claude/scripts/run-verify-plan.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Run `<tf-binary> plan` for drift verification and capture its output.
-# Shared by guard-existing-pr.sh (stale-PR detection) and
-# verify-drift-resolved.sh (no-change gate) so both use identical plan
-# conditions.
+# Used by verify-drift-resolved.sh (no-change gate).
+# TODO: share with guard-existing-pr.sh stale-PR detection to keep plan
+# flags identical between the two checks.
 #
 # Usage: run-verify-plan.sh OUT_FILE
 # Env:   DIR, TF_BINARY
@@ -25,4 +25,6 @@ set +e
 # 2>&1: plan errors go to stderr; capture them so the fail branch and
 # the draft PR body are not empty on exit code 1.
 (cd "$DIR" && "$TF_BINARY" plan -no-color -lock-timeout=300s $CONCISE_FLAG -detailed-exitcode) > "$OUT_FILE" 2>&1
-exit $?
+PLAN_EXIT=$?
+set -e
+exit $PLAN_EXIT

--- a/drift-fix-claude/scripts/verify-drift-resolved.sh
+++ b/drift-fix-claude/scripts/verify-drift-resolved.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# No-change gate: deterministically verify Claude's fix by re-running plan
+# and requiring "No changes". A remaining plan that would destroy and
+# recreate (-/+ or +/-) a resource is never handed off, even as a draft PR.
+# The verdict mapping lives in no-change-gate.sh.
+#
+# Env:    DIR, TF_BINARY, MODE, GH_TOKEN and EXISTING_PR_NUMBER
+#         (the last three only matter on the update + resolved path below)
+# Writes: verdict / fix-verified / summary (resolved only) to GITHUB_OUTPUT,
+#         summary to GITHUB_STEP_SUMMARY, plan output (stdout+stderr) to
+#         /tmp/verify-plan.txt (reused by create-pr.sh for the draft PR body)
+set -euo pipefail
+
+: "${DIR:?DIR is required}"
+: "${TF_BINARY:?TF_BINARY is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# git status --porcelain also catches newly created .tf files,
+# unlike git diff (assumes init artifacts like .terraform/ are
+# gitignored in the consumer repo, same as commit-and-push.sh).
+if [ -n "$(git status --porcelain)" ]; then
+  HAS_DIFF=true
+else
+  HAS_DIFF=false
+fi
+
+# Plan execution (flags, output capture) is shared with the guard's
+# stale-PR detection; see scripts/run-verify-plan.sh.
+set +e
+"$SCRIPT_DIR/run-verify-plan.sh" /tmp/verify-plan.txt
+PLAN_EXIT_CODE=$?
+set -e
+
+# Replacement detection: "# <addr> must be replaced" header comments and
+# -/+ / +/- resource action lines. Create-only or destroy-only changes do
+# not match; only a destroy-and-recreate of the same resource does.
+if grep -qE '^[[:space:]]*(# .* must be replaced$|[-+]/[-+] resource )' /tmp/verify-plan.txt; then
+  HAS_REPLACE=true
+else
+  HAS_REPLACE=false
+fi
+
+VERDICT=$("$SCRIPT_DIR/no-change-gate.sh" "$PLAN_EXIT_CODE" "$HAS_DIFF" "$HAS_REPLACE")
+{
+  echo "verdict=$VERDICT"
+  if [ "$VERDICT" = "pr" ]; then
+    echo "fix-verified=true"
+  elif [ "$VERDICT" = "draft-pr" ]; then
+    echo "fix-verified=false"
+  else
+    echo "fix-verified="
+  fi
+} >> "$GITHUB_OUTPUT"
+
+case "$VERDICT" in
+  pr)
+    echo "Verified: plan shows no changes after the fix in \`$DIR\`." >> "$GITHUB_STEP_SUMMARY"
+    ;;
+  resolved)
+    if [ "${MODE:-create}" = "update" ]; then
+      # Drift resolved between the guard's plan and this verify (transient, or
+      # fixed in the console): the existing PR's branch still plans clean and
+      # stays a valid fix awaiting merge. create-pr only runs for pr/draft-pr,
+      # so report the open PR here instead of "no PR needed" (which would
+      # contradict it).
+      : "${EXISTING_PR_NUMBER:?EXISTING_PR_NUMBER is required when MODE=update}"
+      gh pr comment "$EXISTING_PR_NUMBER" --body "🤖 New drift was detected in \`$DIR\` and the automated fix was re-run, but no further changes were needed — this PR's branch already plans clean. Leaving the PR open for review."
+      PR_URL=$(gh pr view "$EXISTING_PR_NUMBER" --json url -q .url)
+      echo "Drift in \`$DIR\` was re-checked on open PR #$EXISTING_PR_NUMBER; its branch already resolves it (no new changes needed)." >> "$GITHUB_STEP_SUMMARY"
+      echo "summary=Drift in \`$DIR\` was re-checked; open PR #$EXISTING_PR_NUMBER already resolves it: $PR_URL" >> "$GITHUB_OUTPUT"
+    else
+      echo "Drift in \`$DIR\` is already resolved; skipping PR creation." >> "$GITHUB_STEP_SUMMARY"
+      echo "summary=Drift in \`$DIR\` was already resolved; no PR needed." >> "$GITHUB_OUTPUT"
+    fi
+    ;;
+  draft-pr)
+    {
+      echo "Verification failed: plan still shows changes after the fix in \`$DIR\`; creating a draft PR."
+      echo
+      # Indented code block: unlike a ``` fence, plan output that
+      # itself contains backticks cannot break out and render as
+      # markdown.
+      sed 's/^/    /' /tmp/verify-plan.txt
+    } >> "$GITHUB_STEP_SUMMARY"
+    ;;
+  replace-fail)
+    {
+      echo "Verification failed: the plan after the fix in \`$DIR\` would destroy and recreate (-/+) resources; refusing to hand off a PR."
+      echo
+      # Indented code block: unlike a ``` fence, plan output that
+      # itself contains backticks cannot break out and render as
+      # markdown.
+      sed 's/^/    /' /tmp/verify-plan.txt
+    } >> "$GITHUB_STEP_SUMMARY"
+    echo "Plan would replace resources in \`$DIR\`; refusing to create a PR."
+    cat /tmp/verify-plan.txt
+    exit 1
+    ;;
+  *)
+    if [ "$PLAN_EXIT_CODE" = "2" ]; then
+      echo "Claude made no changes but drift remains in \`$DIR\`." | tee -a "$GITHUB_STEP_SUMMARY"
+    else
+      echo "Verification plan failed in \`$DIR\` (exit code $PLAN_EXIT_CODE)." | tee -a "$GITHUB_STEP_SUMMARY"
+    fi
+    cat /tmp/verify-plan.txt
+    exit 1
+    ;;
+esac

--- a/drift-fix-claude/scripts/verify-drift-resolved.sh
+++ b/drift-fix-claude/scripts/verify-drift-resolved.sh
@@ -8,13 +8,19 @@
 #         (the last three only matter on the update + resolved path below)
 # Writes: verdict / fix-verified / summary (resolved only) to GITHUB_OUTPUT,
 #         summary to GITHUB_STEP_SUMMARY, plan output (stdout+stderr) to
-#         /tmp/verify-plan.txt (reused by create-pr.sh for the draft PR body)
+#         VERIFY_PLAN_TXT (reused by create-pr.sh for the draft PR body)
 set -euo pipefail
 
 : "${DIR:?DIR is required}"
 : "${TF_BINARY:?TF_BINARY is required}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Derive a per-DIR filename so concurrent matrix jobs don't clobber each other.
+PLAN_SLUG="$(echo "$DIR" | tr '/' '-' | tr -dc 'a-zA-Z0-9._-' | sed 's/^[-.]*//')"
+VERIFY_PLAN_TXT="${RUNNER_TEMP:-/tmp}/verify-plan-${PLAN_SLUG}.txt"
+# Export for create-pr.sh (runs as a subsequent step in the same job).
+echo "VERIFY_PLAN_TXT=$VERIFY_PLAN_TXT" >> "$GITHUB_ENV"
 
 # git status --porcelain also catches newly created .tf files,
 # unlike git diff (assumes init artifacts like .terraform/ are
@@ -25,17 +31,15 @@ else
   HAS_DIFF=false
 fi
 
-# Plan execution (flags, output capture) is shared with the guard's
-# stale-PR detection; see scripts/run-verify-plan.sh.
 set +e
-"$SCRIPT_DIR/run-verify-plan.sh" /tmp/verify-plan.txt
+"$SCRIPT_DIR/run-verify-plan.sh" "$VERIFY_PLAN_TXT"
 PLAN_EXIT_CODE=$?
 set -e
 
 # Replacement detection: "# <addr> must be replaced" header comments and
 # -/+ / +/- resource action lines. Create-only or destroy-only changes do
 # not match; only a destroy-and-recreate of the same resource does.
-if grep -qE '^[[:space:]]*(# .* must be replaced$|[-+]/[-+] resource )' /tmp/verify-plan.txt; then
+if grep -qE '^[[:space:]]*(# .* must be replaced$|[-+]/[-+] resource )' "$VERIFY_PLAN_TXT"; then
   HAS_REPLACE=true
 else
   HAS_REPLACE=false
@@ -44,7 +48,7 @@ fi
 VERDICT=$("$SCRIPT_DIR/no-change-gate.sh" "$PLAN_EXIT_CODE" "$HAS_DIFF" "$HAS_REPLACE")
 {
   echo "verdict=$VERDICT"
-  if [ "$VERDICT" = "pr" ]; then
+  if [ "$VERDICT" = "pr" ] || [ "$VERDICT" = "resolved" ]; then
     echo "fix-verified=true"
   elif [ "$VERDICT" = "draft-pr" ]; then
     echo "fix-verified=false"
@@ -81,7 +85,7 @@ case "$VERDICT" in
       # Indented code block: unlike a ``` fence, plan output that
       # itself contains backticks cannot break out and render as
       # markdown.
-      sed 's/^/    /' /tmp/verify-plan.txt
+      sed 's/^/    /' "$VERIFY_PLAN_TXT"
     } >> "$GITHUB_STEP_SUMMARY"
     ;;
   replace-fail)
@@ -91,10 +95,10 @@ case "$VERDICT" in
       # Indented code block: unlike a ``` fence, plan output that
       # itself contains backticks cannot break out and render as
       # markdown.
-      sed 's/^/    /' /tmp/verify-plan.txt
+      sed 's/^/    /' "$VERIFY_PLAN_TXT"
     } >> "$GITHUB_STEP_SUMMARY"
     echo "Plan would replace resources in \`$DIR\`; refusing to create a PR."
-    cat /tmp/verify-plan.txt
+    cat "$VERIFY_PLAN_TXT"
     exit 1
     ;;
   *)
@@ -103,7 +107,7 @@ case "$VERDICT" in
     else
       echo "Verification plan failed in \`$DIR\` (exit code $PLAN_EXIT_CODE)." | tee -a "$GITHUB_STEP_SUMMARY"
     fi
-    cat /tmp/verify-plan.txt
+    cat "$VERIFY_PLAN_TXT"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Claude の修正後に `plan -detailed-exitcode` をアクション側で独立に再実行し、drift 解消を決定論的に検証する **no-change gate** を追加します。

- **`run-verify-plan.sh`** (新規): plan 実行の共通ランナー（`-no-color` / `-concise` / `-detailed-exitcode`）
- **`no-change-gate.sh`** (新規): 副作用なしの純粋な verdict マッピング
  | verdict | 条件 | 動作 |
  |---------|------|------|
  | `pr` | exit 0 + 差分あり | 通常 PR を作成 |
  | `resolved` | exit 0 + 差分なし | PR 不要（既に解消済み）|
  | `draft-pr` | exit 2 + replace なし | ⚠️ ドラフト PR を作成 |
  | `replace-fail` | exit 2 + `-/+` 検出 | PR 作成を拒否（exit 1）|
  | `fail` | plan error 等 | exit 1 |
- **`verify-drift-resolved.sh`** (新規): 上記を組み合わせて `verdict` / `fix-verified` / `summary` を `GITHUB_OUTPUT` に書き込む
- **`action.yaml`** (変更):
  - Claude ステップ直後に `Verify drift is resolved (no-change gate)` ステップを追加
  - commit / create-pr の条件を `verdict == 'pr' || verdict == 'draft-pr'` に限定（`replace-fail` / `fail` では PR を作成しない）
  - `VERDICT` をハードコードの `'pr'` から `steps.verify.outputs.verdict` へ変更
  - `fix-verified` output を追加

## Test plan

- [ ] drift なし：verify が exit 0 → `verdict=resolved` → commit/PR ステップがスキップされること
- [ ] Claude が完全修正：verify が exit 0 + 差分あり → `verdict=pr` → 通常 PR が作成されること
- [ ] Claude が部分修正（replace なし）：verify が exit 2 → `verdict=draft-pr` → ⚠️ ドラフト PR が作成されること
- [ ] Claude が replace を含む修正：verify が `-/+` を検出 → `verdict=replace-fail` → PR 未作成・ジョブ失敗であること
- [ ] `no-change-gate.sh` の引数バリデーション（不正な HAS_DIFF / HAS_REPLACE で exit 64）

🤖 Generated with [Claude Code](https://claude.com/claude-code)