### PR TITLE
feat: tofu state list アクションを追加

### DIFF
--- a/.github/examples-workflows/state-list.yaml
+++ b/.github/examples-workflows/state-list.yaml
@@ -1,0 +1,31 @@
+# Run tofu state list with optional filter
+name: State List
+run-name: State List (${{ inputs.dir }}) filter=${{ inputs.filter }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dir:
+        description: Directory to run in
+        type: choice
+        required: true
+        default: dev
+        options:
+          - dev
+          - prod
+      filter:
+        description: grep filter (empty = show all)
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  state-list:
+    uses: gmo-media/tofu-actions/.github/workflows/quickstart-state-list.yaml@v5
+    with:
+      dir: ${{ inputs.dir }}
+      filter: ${{ inputs.filter }}

--- a/.github/workflows/quickstart-state-list.yaml
+++ b/.github/workflows/quickstart-state-list.yaml
@@ -1,0 +1,29 @@
+# Run tofu state list with optional filter
+name: State List
+run-name: State List (${{ inputs.dir }}) filter=${{ inputs.filter }}
+
+on:
+  workflow_call:
+    inputs:
+      dir:
+        description: Directory to run in
+        type: string
+        required: true
+      filter:
+        description: grep filter (empty = show all)
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  state-list:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gmo-media/tofu-actions/state-list@v5
+        with:
+          dir: ${{ inputs.dir }}
+          filter: ${{ inputs.filter }}

--- a/state-list/action.yaml
+++ b/state-list/action.yaml
@@ -1,0 +1,35 @@
+name: State List
+description: Runs tofu state list with an optional grep filter.
+
+inputs:
+  config:
+    description: tofu-actions config file
+    default: .github/tofu-actions-config.js
+  dir:
+    description: Directory to run in
+    required: true
+  filter:
+    description: grep filter (empty = show all)
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - id: configure
+      uses: gmo-media/tofu-actions/configure@v5
+      with:
+        config: ${{ inputs.config }}
+        dir: ${{ inputs.dir }}
+
+    - name: tofu state list
+      working-directory: ${{ inputs.dir }}
+      shell: bash
+      env:
+        TF_BINARY: ${{ steps.configure.outputs.tf-binary }}
+        FILTER: ${{ inputs.filter }}
+      run: |
+        if [ -n "$FILTER" ]; then
+          $TF_BINARY state list | grep -F "$FILTER" || true
+        else
+          $TF_BINARY state list
+        fi


### PR DESCRIPTION
## 変更内容

- `state-list/action.yaml` — `tofu state list` をオプションのフィルタ付きで実行するコンポジットアクションを追加
- `.github/workflows/quickstart-state-list.yaml` — `workflow_call` で呼び出し可能なクイックスタートワークフローを追加
- `.github/examples-workflows/state-list.yaml` — `workflow_dispatch` で手動実行するサンプルワークフローを追加

## 実装上のポイント

- `configure` ステップに `id: configure` を付与し、`tf-binary` 出力（`tofu` または `terraform`）を後続ステップで参照
- `tofu` のハードコードを避け、`$TF_BINARY` 経由で正しいバイナリを使用
- `grep -F` で固定文字列マッチ（Terraform リソースアドレスの `[0]` 等をそのまま検索可能）
- `|| true` でフィルタにヒットするリソースがゼロ件でもステップが失敗しないように対処

## 確認事項

- [ ] `dir: dev` / `dir: prod` を選択して workflow_dispatch で動作確認
- [ ] `filter` を空にしたとき全リソースが表示されること
- [ ] `filter` に一致するリソースがないとき空で正常終了すること
- [ ] `filter` に `module.foo[0]` のようなアドレスを指定しても正しくフィルタされること