### PR TITLE
fix: Slack通知の既存PRリンクをクリック可能にする

### DIFF
--- a/drift-fix-claude/scripts/guard-existing-pr.sh
+++ b/drift-fix-claude/scripts/guard-existing-pr.sh
@@ -95,7 +95,7 @@ if [ "$HAS_HUMAN" = "true" ]; then
   {
     echo "skip=true"
     echo "existing-pr-number=$EXISTING_PR"
-    echo "summary=Drift detected in \`$DIR\`; open PR #$EXISTING_PR has human commits (handled manually)."
+    echo "summary=Drift detected in \`$DIR\`; open <${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${EXISTING_PR}|PR #${EXISTING_PR}> has human commits (handled manually)."
   } >> "$GITHUB_OUTPUT"
   echo "Skipped drift fix for \`$DIR\`: open PR #$EXISTING_PR has human commits." >> "$GITHUB_STEP_SUMMARY"
   exit 0
@@ -146,7 +146,7 @@ case "$PLAN_EXIT_CODE" in
     {
       echo "skip=true"
       echo "existing-pr-number=$EXISTING_PR"
-      echo "summary=Drift detected in \`$DIR\`; open PR #$EXISTING_PR already resolves it."
+      echo "summary=Drift detected in \`$DIR\`; open <${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${EXISTING_PR}|PR #${EXISTING_PR}> already resolves it."
     } >> "$GITHUB_OUTPUT"
     echo "Skipped drift fix for \`$DIR\`: open PR #$EXISTING_PR still resolves the drift." >> "$GITHUB_STEP_SUMMARY"
     ;;

--- a/drift-fix-claude/scripts/verify-drift-resolved.sh
+++ b/drift-fix-claude/scripts/verify-drift-resolved.sh
@@ -72,7 +72,7 @@ case "$VERDICT" in
       gh pr comment "$EXISTING_PR_NUMBER" --body "🤖 New drift was detected in \`$DIR\` and the automated fix was re-run, but no further changes were needed — this PR's branch already plans clean. Leaving the PR open for review."
       PR_URL=$(gh pr view "$EXISTING_PR_NUMBER" --json url -q .url)
       echo "Drift in \`$DIR\` was re-checked on open PR #$EXISTING_PR_NUMBER; its branch already resolves it (no new changes needed)." >> "$GITHUB_STEP_SUMMARY"
-      echo "summary=Drift in \`$DIR\` was re-checked; open PR #$EXISTING_PR_NUMBER already resolves it: $PR_URL" >> "$GITHUB_OUTPUT"
+      echo "summary=Drift in \`$DIR\` was re-checked; open <${PR_URL}|PR #${EXISTING_PR_NUMBER}> already resolves it." >> "$GITHUB_OUTPUT"
     else
       echo "Drift in \`$DIR\` is already resolved; skipping PR creation." >> "$GITHUB_STEP_SUMMARY"
       echo "summary=Drift in \`$DIR\` was already resolved; no PR needed." >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 変更内容

既にドリフト修正PRが公開済みの場合にSlack通知が飛ぶ際、PR番号が単なるテキストになっていてGitHubに遷移できなかった問題を修正。

Slack mrkdwn 形式の `<URL|PR #N>` に変更することで、通知内のリンクをクリックするとGitHubのPRページに遷移するようになります。

### 修正したパターン

- `guard-existing-pr.sh` — 既存PRがドリフトを解消済みでスキップする場合
- `guard-existing-pr.sh` — 既存PRにヒューマンコミットがあってスキップする場合
- `verify-drift-resolved.sh` — updateモードで再検証しても既存PRで解消済みだった場合

### Before

```
Infrastructure drift has been detected. Drift detected in `prod/eks`; open PR #484 already resolves it.
```

### After

```
Infrastructure drift has been detected. Drift detected in `prod/eks`; open PR #484 already resolves it.
```
（「PR #484」部分がGitHub PRページへのリンクになる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)