### PR TITLE
chore(deps): Node.js 24 対応アクションに更新

### DIFF
--- a/configure/action.yaml
+++ b/configure/action.yaml
@@ -32,7 +32,7 @@ runs:
         dir: ${{ inputs.dir }}
 
     - if: ${{ contains(steps.config.outputs.auth-mode, 'aws-oidc') }}
-      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         aws-region: ${{ steps.config.outputs.auth-aws-region }}
         role-to-assume: ${{ inputs.mode == 'apply' && steps.config.outputs.auth-aws-apply-role || steps.config.outputs.auth-aws-plan-role }}
@@ -63,7 +63,7 @@ runs:
       with:
         terraform_wrapper: false
     - if: ${{ steps.config.outputs.tf-binary == 'tofu' }}
-      uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1.0.8
+      uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
       with:
         tofu_version_file: .opentofu-version
         tofu_wrapper: 'false'

--- a/plan/action.yaml
+++ b/plan/action.yaml
@@ -86,12 +86,12 @@ runs:
         fi
 
     - name: Upload plan text
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: plan-text-${{ steps.artifact-name.outputs.name }}
         path: /tmp/plan-${{ steps.artifact-name.outputs.name }}.txt
     - name: Upload plan file
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: plan-file-${{ steps.artifact-name.outputs.name }}
         path: /tmp/tf.plan


### PR DESCRIPTION
## Summary

Node.js 20 向けビルドのアクションを Node.js 24 対応版に更新します。

| アクション | 変更前 | 変更後 | URL
|---|---|---|---|
| `actions/upload-artifact` | v4 | v7.0.1 | https://github.com/actions/upload-artifact/releases/tag/v7.0.1
| `aws-actions/configure-aws-credentials` | v5 | v6.2.0 | https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.2.0
| `opentofu/setup-opentofu` | v1.0.8 | v2.0.1 | https://github.com/opentofu/setup-opentofu/releases/tag/v2.0.1

入力パラメータ（`name`、`path`、`aws-region`、`role-to-assume`、`tofu_version_file`、`tofu_wrapper`）はすべて最新バージョンで有効であることを確認済みです。

## Test plan

- [ ] `configure/action.yaml` を使用するワークフロー（AWS OIDC 認証 + OpenTofu）が正常に動作することを確認
- [ ] `plan/action.yaml` を使用するワークフローでアーティファクトのアップロードが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)