### PR TITLE
fix(fix-drift): remove orphaned import/moved blocks when deleting resources

### DIFF
--- a/.claude/skills/fix-drift/SKILL.md
+++ b/.claude/skills/fix-drift/SKILL.md
@@ -14,6 +14,7 @@ Your goal is to update the .tf files to match the current real-world infrastruct
 - Only make changes to .tf files and run `$tf_binary plan`.
 - Always choose the least destructive approach. Be surgical and precise with your edits.
 - NEVER leave the configuration in a state where `$tf_binary plan` would destroy and then recreate a resource (the `-/+` / `+/-` actions, shown as "must be replaced" / "forces replacement"). If one of your edits causes a replacement, revert or rework that edit until no replacement remains (e.g. use a `moved` block instead of renaming a resource). A leftover change that only creates or only destroys a resource is tolerable; a paired destroy-and-create of the same resource is not — the verification gate fails the whole run if one remains.
+- When you **delete** a resource block from a .tf file, also search the entire `$dir` for any `import` or `moved` block whose `to` attribute targets that resource address (e.g. `to = aws_instance.example` or `to = module.foo.aws_instance.example`) and delete those blocks as well. Orphaned `import`/`moved` blocks whose target resource no longer exists cause a plan error.
 
 ## Context
 - Directory with drift: $dir
@@ -38,6 +39,7 @@ Try not to be confused by these verbose lines - try to extract only the importan
 2. Fix the drift
 Update .tf files to match the CURRENT REAL INFRASTRUCTURE STATE.
 This means: incorporate the external changes into your .tf files.
+If fixing requires **deleting** a resource block, also remove any `import` or `moved` block targeting that resource anywhere in `$dir`. Search with: `grep -rEn 'to\s*=.*<resource_type>\.<resource_name>' $dir` (the `.*` handles module-prefixed addresses like `module.foo.aws_instance.bar`).
 
 3. Validate
 After making changes, run: `$tf_binary plan` within directory `$dir`.


### PR DESCRIPTION
## 概要

drift-fix でリソースを削除する際、そのリソースを参照している `import` ブロックや `moved` ブロックを合わせて削除するよう Claude への指示（SKILL.md）を追加。

- `import { to = <削除リソース> ... }` — 対象リソースが存在しないとplanエラー
- `moved { ... to = <削除リソース> }` — 同様にplanエラー

## 変更ファイル

- `.claude/skills/fix-drift/SKILL.md`
  - Important Rules に削除時の `import`/`moved` ブロック清掃ルールを追加
  - Step 2 に具体的な grep コマンド例を追加（`grep -rEn` でmacOS/Linux両対応、`.*` でモジュールプレフィックスにも対応）

## Test plan

- [ ] drift-fix が実行されたとき、削除されたリソースに対応する `import` ブロックが .tf ファイルから除去されることを確認
- [ ] モジュール内リソース（`module.foo.aws_instance.bar`）の `import` ブロックも除去されることを確認
- [ ] 削除リソースへの `moved` ブロックも除去されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)